### PR TITLE
feat: add the ability to annotate nested namespaced models

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.4.x', '2.5.x', '2.6.x']
+        ruby: ['2.4.10', '2.5.9', '2.6.8']
 
     steps:
       - name: Checkout
         uses: actions/checkout@v1
 
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1.79.0
         with:
           ruby-version: ${{ matrix.ruby }}
 

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -404,32 +404,11 @@ module AnnotateModels
       if old_annotation.empty? || options[:force]
         old_content.sub!(annotate_pattern(options), '')
 
-        if %w(after bottom).include?(options[position].to_s)
-          module_end_block = ''
-          unless module_block.empty?
-            # build expected end block for each nested module with no extra lines between end statements
-            module_end_block = (module_block.lines.length - 1).downto(0).map { |l| (' ' * l * 2) + 'end' }.join("\n")
-            # remove an identical end block.
-            old_content.gsub!("\n#{module_end_block}", '')
-          end
-          new_content = old_content.rstrip + "\n\n" + wrapped_info_block + module_end_block
-        else
-          magic_comments_block = magic_comments_as_string(old_content)
-          old_content.gsub!(MAGIC_COMMENT_MATCHER, '')
-
-          unless module_block.empty?
-            # remove the module block.
-            old_content.gsub!(/\n?#{module_block}/, '')
-          end
-
-          if magic_comments_block.empty?
-            new_content = module_block + wrapped_info_block + old_content
-          elsif module_block.empty?
-            new_content = magic_comments_block + "\n" + wrapped_info_block + old_content.lstrip
-          else
-            new_content = magic_comments_block + "\n" + module_block.lstrip + wrapped_info_block + old_content
-          end
-        end
+        new_content = if %w(after bottom).include?(options[position].to_s)
+                        build_new_content_after(wrapped_info_block, old_content, module_block)
+                      else
+                        build_new_content_before(wrapped_info_block, old_content, module_block)
+                      end
       else
         # replace the old annotation with the new one
 
@@ -447,6 +426,35 @@ module AnnotateModels
 
       File.open(file_name, 'wb') { |f| f.puts new_content }
       true
+    end
+
+    def build_new_content_after(wrapped_info_block, old_content, module_block)
+      module_end_block = ''
+      unless module_block.empty?
+        # build expected end block for each nested module with no extra lines between end statements
+        module_end_block = (module_block.lines.length - 1).downto(0).map { |l| (' ' * l * 2) + 'end' }.join("\n")
+        # remove an identical end block.
+        old_content.gsub!("\n#{module_end_block}", '')
+      end
+      old_content.rstrip + "\n\n" + wrapped_info_block + module_end_block
+    end
+
+    def build_new_content_before(wrapped_info_block, old_content, module_block)
+      magic_comments_block = magic_comments_as_string(old_content)
+      old_content.gsub!(MAGIC_COMMENT_MATCHER, '')
+
+      unless module_block.empty?
+        # remove the module block.
+        old_content.gsub!(/\n?#{module_block}/, '')
+      end
+
+      if magic_comments_block.empty?
+        module_block + wrapped_info_block + old_content
+      elsif module_block.empty?
+        magic_comments_block + "\n" + wrapped_info_block + old_content.lstrip
+      else
+        magic_comments_block + "\n" + module_block.lstrip + wrapped_info_block + old_content
+      end
     end
 
     def magic_comments_as_string(content)

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -41,12 +41,15 @@ module AnnotateModels
 
   MAGIC_COMMENT_MATCHER = Regexp.new(/(^#\s*encoding:.*(?:\n|r\n))|(^# coding:.*(?:\n|\r\n))|(^# -\*- coding:.*(?:\n|\r\n))|(^# -\*- encoding\s?:.*(?:\n|\r\n))|(^#\s*frozen_string_literal:.+(?:\n|\r\n))|(^# -\*- frozen_string_literal\s*:.+-\*-(?:\n|\r\n))/).freeze
 
+  # match a basic nested module block with no extra lines between modules.
+  MODULE_BLOCK_MATCHER = Regexp.new(/( *module \w+(\n|\r\n))+/).freeze
+
   class << self
     def annotate_pattern(options = {})
       if options[:wrapper_open]
-        return /(?:^(\n|\r\n)?# (?:#{options[:wrapper_open]}).*(\n|\r\n)?# (?:#{COMPAT_PREFIX}|#{COMPAT_PREFIX_MD}).*?(\n|\r\n)(#.*(\n|\r\n))*(\n|\r\n)*)|^(\n|\r\n)?# (?:#{COMPAT_PREFIX}|#{COMPAT_PREFIX_MD}).*?(\n|\r\n)(#.*(\n|\r\n))*(\n|\r\n)*/
+        return /(?:^(\n|\r\n)? *# (?:#{options[:wrapper_open]}).*(\n|\r\n)? *# (?:#{COMPAT_PREFIX}|#{COMPAT_PREFIX_MD}).*?(\n|\r\n)( *#.*(\n|\r\n))*(\n|\r\n)*)|^(\n|\r\n)? *# (?:#{COMPAT_PREFIX}|#{COMPAT_PREFIX_MD}).*?(\n|\r\n)( *#.*(\n|\r\n))*(\n|\r\n)*/
       end
-      /^(\n|\r\n)?# (?:#{COMPAT_PREFIX}|#{COMPAT_PREFIX_MD}).*?(\n|\r\n)(#.*(\n|\r\n))*(\n|\r\n)*/
+      /^(\n|\r\n)? *# (?:#{COMPAT_PREFIX}|#{COMPAT_PREFIX_MD}).*?(\n|\r\n)( *#.*(\n|\r\n))*(\n|\r\n)*/
     end
 
     def model_dir
@@ -369,13 +372,16 @@ module AnnotateModels
       return false if old_content =~ /#{SKIP_ANNOTATION_PREFIX}.*\n/
 
       # Ignore the Schema version line because it changes with each migration
-      header_pattern = /(^# Table name:.*?\n(#.*[\r]?\n)*[\r]?)/
+      header_pattern = /(^ *# Table name:.*?\n( *#.*[\r]?\n)*[\r]?)/
       old_header = old_content.match(header_pattern).to_s
       new_header = info_block.match(header_pattern).to_s
 
-      column_pattern = /^#[\t ]+[\w\*\.`]+[\t ]+.+$/
+      column_pattern = /^ *#[\t ]+[\w\*\.`]+[\t ]+.+$/
       old_columns = old_header && old_header.scan(column_pattern).sort
       new_columns = new_header && new_header.scan(column_pattern).sort
+
+      # remove indentation from old content for comparison
+      old_columns.each { |c| c.gsub!(/^ *#/, '#') }
 
       return false if old_columns == new_columns && !options[:force]
 
@@ -386,28 +392,55 @@ module AnnotateModels
       wrapper_close = options[:wrapper_close] ? "# #{options[:wrapper_close]}\n" : ""
       wrapped_info_block = "#{wrapper_open}#{info_block}#{wrapper_close}"
 
+      module_block = old_content[MODULE_BLOCK_MATCHER] || ''
+      unless module_block.empty?
+        wrapped_info_block = indent_content(wrapped_info_block, module_block.lines.length * 2)
+      end
+
       old_annotation = old_content.match(annotate_pattern(options)).to_s
 
       # if there *was* no old schema info or :force was passed, we simply
       # need to insert it in correct position
       if old_annotation.empty? || options[:force]
-        magic_comments_block = magic_comments_as_string(old_content)
-        old_content.gsub!(MAGIC_COMMENT_MATCHER, '')
         old_content.sub!(annotate_pattern(options), '')
 
-        new_content = if %w(after bottom).include?(options[position].to_s)
-                        magic_comments_block + (old_content.rstrip + "\n\n" + wrapped_info_block)
-                      elsif magic_comments_block.empty?
-                        magic_comments_block + wrapped_info_block + old_content.lstrip
-                      else
-                        magic_comments_block + "\n" + wrapped_info_block + old_content.lstrip
-                      end
+        if %w(after bottom).include?(options[position].to_s)
+          module_end_block = ''
+          unless module_block.empty?
+            # build expected end block for each nested module with no extra lines between end statements
+            module_end_block = (module_block.lines.length - 1).downto(0).map { |l| (' ' * l * 2) + 'end' }.join("\n")
+            # remove an identical end block.
+            old_content.gsub!("\n#{module_end_block}", '')
+          end
+          new_content = old_content.rstrip + "\n\n" + wrapped_info_block + module_end_block
+        else
+          magic_comments_block = magic_comments_as_string(old_content)
+          old_content.gsub!(MAGIC_COMMENT_MATCHER, '')
+
+          unless module_block.empty?
+            # remove the module block.
+            old_content.gsub!(/\n?#{module_block}/, '')
+          end
+
+          if magic_comments_block.empty?
+            new_content = module_block + wrapped_info_block + old_content
+          elsif module_block.empty?
+            new_content = magic_comments_block + "\n" + wrapped_info_block + old_content.lstrip
+          else
+            new_content = magic_comments_block + "\n" + module_block.lstrip + wrapped_info_block + old_content
+          end
+        end
       else
         # replace the old annotation with the new one
 
         # keep the surrounding whitespace the same
         space_match = old_annotation.match(/\A(?<start>\s*).*?\n(?<end>\s*)\z/m)
         new_annotation = space_match[:start] + wrapped_info_block + space_match[:end]
+
+        unless module_block.empty?
+          # remove extra indentation for the first line.
+          new_annotation = new_annotation[(module_block.lines.length * 2)..-1]
+        end
 
         new_content = old_content.sub(annotate_pattern(options), new_annotation)
       end
@@ -424,6 +457,10 @@ module AnnotateModels
       else
         ''
       end
+    end
+
+    def indent_content(content, indentation)
+      content.lines.map { |line| ' ' * indentation + line }.join
     end
 
     def remove_annotation_of_file(file_name, options = {})

--- a/spec/integration/rails_5.2.4.1/Gemfile
+++ b/spec/integration/rails_5.2.4.1/Gemfile
@@ -6,7 +6,7 @@ gem 'rails', '~> 5.2.4', '>= 5.2.4.1'
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3'
 # Use Puma as the app server
-gem 'puma', '~> 4.3'
+gem 'puma', '~> 4.3.8'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets

--- a/spec/integration/rails_5.2.4.1/Gemfile.lock
+++ b/spec/integration/rails_5.2.4.1/Gemfile.lock
@@ -102,7 +102,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
-    mimemagic (0.3.4)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.0)
@@ -111,7 +113,7 @@ GEM
     nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
     public_suffix (4.0.3)
-    puma (4.3.3)
+    puma (4.3.8)
       nio4r (~> 2.0)
     rack (2.1.2)
     rack-test (1.1.0)
@@ -202,7 +204,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
-  puma (~> 4.3)
+  puma (~> 4.3.8)
   rails (~> 5.2.4, >= 5.2.4.1)
   sass-rails (~> 5.0)
   selenium-webdriver
@@ -213,4 +215,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   2.1.2
+   2.2.15

--- a/spec/integration/rails_6.0.2.1/Gemfile
+++ b/spec/integration/rails_6.0.2.1/Gemfile
@@ -6,7 +6,7 @@ gem 'rails', '~> 6.0.2', '>= 6.0.2.1'
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3', '~> 1.4'
 # Use Puma as the app server
-gem 'puma', '~> 4.3'
+gem 'puma', '~> 4.3.8'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.7'
 # Use Redis adapter to run Action Cable in production

--- a/spec/integration/rails_6.0.2.1/Gemfile.lock
+++ b/spec/integration/rails_6.0.2.1/Gemfile.lock
@@ -101,7 +101,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
-    mimemagic (0.3.4)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.0)
@@ -110,7 +112,7 @@ GEM
     nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
     public_suffix (4.0.3)
-    puma (4.3.3)
+    puma (4.3.8)
       nio4r (~> 2.0)
     rack (2.1.2)
     rack-test (1.1.0)
@@ -189,7 +191,7 @@ DEPENDENCIES
   capybara (>= 2.15)
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
-  puma (~> 4.3)
+  puma (~> 4.3.8)
   rails (~> 6.0.2, >= 6.0.2.1)
   selenium-webdriver
   sqlite3 (~> 1.4)
@@ -198,4 +200,4 @@ DEPENDENCIES
   webdrivers
 
 BUNDLED WITH
-   2.1.2
+   2.2.15

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -2725,7 +2725,7 @@ describe AnnotateModels do
         EOS
         annotate_one_file position: :before
         expect(File.read(@model_file_name)).to eq(
-          <<~HEREDOC,
+          <<~HEREDOC
             module Foo
               # == Schema Info
               #
@@ -2782,7 +2782,7 @@ describe AnnotateModels do
         EOS
         annotate_one_file position: :after
         expect(File.read(@model_file_name)).to eq(
-          <<~HEREDOC,
+          <<~HEREDOC
             module Foo
               # my docs
               class User < ActiveRecord::Base

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -2539,13 +2539,14 @@ describe AnnotateModels do
     def annotate_one_file(options = {})
       Annotate.set_defaults(options)
       options = Annotate.setup_options(options)
-      AnnotateModels.annotate_one_file(@model_file_name, @schema_info, :position_in_class, options)
+      result = AnnotateModels.annotate_one_file(@model_file_name, @schema_info, :position_in_class, options)
 
       # Wipe settings so the next call will pick up new values...
       Annotate.instance_variable_set('@has_set_defaults', false)
       Annotate::Constants::POSITION_OPTIONS.each { |key| ENV[key.to_s] = '' }
       Annotate::Constants::FLAG_OPTIONS.each { |key| ENV[key.to_s] = '' }
       Annotate::Constants::PATH_OPTIONS.each { |key| ENV[key.to_s] = '' }
+      result
     end
 
     ['before', :before, 'top', :top].each do |position|
@@ -2568,6 +2569,60 @@ describe AnnotateModels do
       annotate_one_file wrapper_open: 'START', wrapper_close: 'END'
       expect(File.read(@model_file_name))
         .to eq("# START\n#{@schema_info}# END\n#{@file_content}")
+    end
+
+    describe 'handles nested namespaced models without magic comments' do
+      before do
+        _, file_content = write_model 'user.rb', <<~EOS
+          module Foo
+            # my docs
+            class User < ActiveRecord::Base
+            end
+          end
+        EOS
+
+        @indented_schema = AnnotateModels.indent_content(@schema_info, 2)
+        @class_block = file_content.lines[1...-1].join[0...-1]
+      end
+
+      it 'should place the comment above the class when before' do
+        annotate_one_file position: :before
+        expect(File.read(@model_file_name)).to eq("module Foo\n#{@indented_schema}#{@class_block}\nend\n")
+      end
+
+      it 'should place the comment below the class when after' do
+        annotate_one_file position: :after
+        expect(File.read(@model_file_name)).to eq("module Foo\n#{@class_block}\n\n#{@indented_schema}end\n")
+      end
+    end
+
+    describe 'handles nested namespaced models with magic comments' do
+      before do
+        _, file_content = write_model 'user.rb', <<~EOS
+          # frozen_string_literal: true
+
+          module Foo
+            # my docs
+            class User < ActiveRecord::Base
+            end
+          end
+        EOS
+
+        @indented_schema = AnnotateModels.indent_content(@schema_info, 2)
+        @class_block = file_content.lines[3...-1].join[0...-1]
+      end
+
+      it 'should place the comment above the class when before' do
+        annotate_one_file position: :before
+        expect(File.read(@model_file_name))
+          .to eq("# frozen_string_literal: true\n\nmodule Foo\n#{@indented_schema}#{@class_block}\nend\n")
+      end
+
+      it 'should place the comment below the class when after' do
+        annotate_one_file position: :after
+        expect(File.read(@model_file_name))
+          .to eq("# frozen_string_literal: true\n\nmodule Foo\n#{@class_block}\n\n#{@indented_schema}end\n")
+      end
     end
 
     describe 'with existing annotation' do
@@ -2634,6 +2689,58 @@ describe AnnotateModels do
         annotate_one_file position: :after, force: true
         expect(File.read(@model_file_name)).to eq("#{@file_content}\n#{@schema_info}")
       end
+
+      it 'should skip nested namespaced models that did not change' do
+        write_model 'user.rb', <<~EOS
+          module Foo
+            # == Schema Info
+            #
+            # Table name: users
+            #
+            #  id :integer          not null, primary key
+            #
+
+            # my docs
+            class User < ActiveRecord::Base
+            end
+          end
+        EOS
+        expect(annotate_one_file(position: :before)).to be_falsy
+      end
+
+      it 'should retain the current position for nested namesapced models' do
+        write_model 'user.rb', <<~EOS
+          module Foo
+            # == Schema Info
+            #
+            # Table name: users
+            #
+            #  id :integer          not null, primary key
+            #  user_id              indexed
+
+            # my docs
+            class User < ActiveRecord::Base
+            end
+          end
+        EOS
+        annotate_one_file position: :before
+        expect(File.read(@model_file_name)).to eq(
+          <<~HEREDOC,
+            module Foo
+              # == Schema Info
+              #
+              # Table name: users
+              #
+              #  id :integer          not null, primary key
+              #
+
+              # my docs
+              class User < ActiveRecord::Base
+              end
+            end
+          HEREDOC
+        )
+      end
     end
 
     describe 'with existing annotation => :after' do
@@ -2656,6 +2763,39 @@ describe AnnotateModels do
       it 'should change position to :before when force: true' do
         annotate_one_file position: :before, force: true
         expect(File.read(@model_file_name)).to eq("#{@schema_info}#{@file_content}")
+      end
+
+      it 'should retain the current position for nested namesapced models' do
+        write_model 'user.rb', <<~EOS
+          module Foo
+            # my docs
+            class User < ActiveRecord::Base
+            end
+            # == Schema Info
+            #
+            # Table name: users
+            #
+            #  id :integer          not null, primary key
+            #  user_id              indexed
+            #
+          end
+        EOS
+        annotate_one_file position: :after
+        expect(File.read(@model_file_name)).to eq(
+          <<~HEREDOC,
+            module Foo
+              # my docs
+              class User < ActiveRecord::Base
+              end
+              # == Schema Info
+              #
+              # Table name: users
+              #
+              #  id :integer          not null, primary key
+              #
+            end
+          HEREDOC
+        )
       end
     end
 


### PR DESCRIPTION
This PR adds the ability to annotated nested namespaced models. For example:
```rb
module Fulfillment
  class DeliveryAvailableToPick < ApplicationRecord
    # ...
  end
end
```
The original behavior was to always add the model annotation above the root module. However, this breaks YARD documentation, because it is used for the module docs instead of the class docs. This feature will annotate the actual model class. For example:
```rb
module Fulfillment
  # == Schema Information
  #
  # Table name: fulfillment.deliveries_available_to_pick
  #
  #  id          :bigint(8)        not null, primary key
  #  created_at  :datetime         not null
  #
  class DeliveryAvailableToPick < ApplicationRecord
    # ...
  end
end
```
It contains the following changes:
1) Adjust the annotation matchers so they find indented comments.
2) Remove the indentation when comparing new and old annotations.
3) Parse module blocks (beginning and end) and insert indented comments before or after the class.

The current module matching is very rigid and expects module declarations to contain no lines (blank, comments, variables, methods etc) between any nested modules and the class declaration.